### PR TITLE
Add incorrect login message above login page EditTexts

### DIFF
--- a/app/src/main/java/com/cs407/attendanceapp/LoginPage.java
+++ b/app/src/main/java/com/cs407/attendanceapp/LoginPage.java
@@ -14,6 +14,8 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 
+import org.w3c.dom.Text;
+
 public class LoginPage extends AppCompatActivity {
 
     @Override
@@ -22,6 +24,22 @@ public class LoginPage extends AppCompatActivity {
         setContentView(R.layout.page_login);
         FirebaseApp.initializeApp(this);
         FirebaseFirestore db = FirebaseFirestore.getInstance();
+
+        EditText emailEditText = findViewById(R.id.emailEditText);
+        EditText passwordEditText = findViewById(R.id.passwordEditText);
+
+        emailEditText.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                removeIncorrectLoginMessage();
+            }
+        });
+        passwordEditText.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                removeIncorrectLoginMessage();
+            }
+        });
 
         // PULL FROM FIRESTORE
 //        db.collection("Test")
@@ -78,14 +96,15 @@ public class LoginPage extends AppCompatActivity {
         String email = emailTextField.getText().toString();
         EditText passwordTextField = (EditText) findViewById(R.id.passwordEditText);
         String password = passwordTextField.getText().toString();
+
         if(email == null || password == null) {
             Log.e("Login Error", "Invalid username or password");
+            displayIncorrectLoginMessage();
         } else {
             checkLogin(email, password);
         }
     }
     public void checkLogin(String email, String password) {
-
         FirebaseApp.initializeApp(this);
         FirebaseFirestore db = FirebaseFirestore.getInstance();
         db.collection("users")
@@ -100,9 +119,13 @@ public class LoginPage extends AppCompatActivity {
                             if (passwordValue.equals(password)) {
                                 Log.i("Info", "Made it here");
                                 goToHomePage(userType);
+                            } else {
+                                Log.i("Info", "Invalid email or password");
+                                displayIncorrectLoginMessage();
                             }
                         } else {
                             Log.d("Firestore Data", "No such document");
+                            displayIncorrectLoginMessage(); // email wasn't found?
                         }
                     } else {
                         Log.e("Firestore Error", "Error getting document", task.getException());
@@ -122,5 +145,15 @@ public class LoginPage extends AppCompatActivity {
     public void signUpClick(View view) {
         Intent intent = new Intent(this, SignUpPage.class);
         startActivity(intent);
+    }
+
+    public void displayIncorrectLoginMessage() {
+        TextView incorrectLoginText = findViewById(R.id.incorrectLoginText);
+        incorrectLoginText.setText("Invalid email or password");
+    }
+
+    public void removeIncorrectLoginMessage() {
+        TextView incorrectLoginText = findViewById(R.id.incorrectLoginText);
+        incorrectLoginText.setText("");
     }
 }

--- a/app/src/main/res/layout/page_login.xml
+++ b/app/src/main/res/layout/page_login.xml
@@ -31,6 +31,7 @@
         android:textSize="60sp"
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.495"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -90,5 +91,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/incorrectLoginText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:textColor="#201F1F"
+        app:flow_horizontalAlign="center"
+        app:layout_constraintBottom_toTopOf="@+id/emailEditText"
+        app:layout_constraintEnd_toEndOf="@+id/emailEditText"
+        app:layout_constraintHorizontal_bias="0.428"
+        app:layout_constraintStart_toStartOf="@+id/emailEditText" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Before:
- No display to the user when login is incorrect

## After:
- There is a text box that displays an incorrect login message when the login is incorrect
- If the user taps the enter email or enter password textbox and starts typing, the message clears

## What to do to verify:
- Make sure you have at least one account in the app
- Try entering an incorrect email with any password, click login. You should see the message display above the login text boxes.
- When you click either TextEdit, the incorrect login message should clear. Try entering a correct email, but incorrect password.  Click login. You should see the message display above the login text boxes.
- Try clicking on whichever TextEdit you clicked second in the last step first this time and try typing something new in. The incorrect login message should clear.